### PR TITLE
Init views on first connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # generated test data paths
 test-runs/
+
+# any generated parquet files -- must manually add any source files
+.parquet

--- a/.gitignore
+++ b/.gitignore
@@ -88,13 +88,6 @@ ipython_config.py
 # pyenv
 .python-version
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 
@@ -104,6 +97,9 @@ celerybeat.pid
 
 # SageMath parsed files
 *.sage.py
+
+# MacOS stuff]
+.DS_Store
 
 # Environments
 .env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: "^tests/.*"
 
 
 default_language_version:
-  python: python3.8
+  python: python3.10
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -17,6 +17,10 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
   - id: check-case-conflict
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
+  hooks:
+  - id: reorder-python-imports
 - repo: https://github.com/psf/black
   rev: 22.3.0
   hooks:
@@ -40,15 +44,15 @@ repos:
     alias: flake8-check
     stages: [manual]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.782
+  rev: v0.982
   hooks:
   - id: mypy
-    args: [--show-error-codes, --ignore-missing-imports]
+    args: [--show-error-codes, --ignore-missing-imports, --explicit-package-bases]
     files: ^dbt/adapters/.*
     language: system
   - id: mypy
     alias: mypy-check
     stages: [manual]
-    args: [--show-error-codes, --pretty, --ignore-missing-imports]
+    args: [--show-error-codes, --pretty, --ignore-missing-imports, --explicit-package-bases]
     files: ^dbt/adapters
     language: system

--- a/dbt/adapters/parquet/__init__.py
+++ b/dbt/adapters/parquet/__init__.py
@@ -1,11 +1,12 @@
+from dbt.adapters.base import AdapterPlugin
 from dbt.adapters.parquet.connections import ParquetConnectionManager  # noqa
 from dbt.adapters.parquet.connections import ParquetCredentials
 from dbt.adapters.parquet.impl import ParquetAdapter
-
-from dbt.adapters.base import AdapterPlugin
 from dbt.include import parquet
 
 
 Plugin = AdapterPlugin(
-    adapter=ParquetAdapter, credentials=ParquetCredentials, include_path=parquet.PACKAGE_PATH
+    adapter=ParquetAdapter,  # type: ignore
+    credentials=ParquetCredentials,
+    include_path=parquet.PACKAGE_PATH,
 )

--- a/dbt/adapters/parquet/__version__.py
+++ b/dbt/adapters/parquet/__version__.py
@@ -1,1 +1,1 @@
-version = "1.2.1"
+version = "1.3.0"

--- a/dbt/adapters/parquet/connections.py
+++ b/dbt/adapters/parquet/connections.py
@@ -1,27 +1,40 @@
-from dataclasses import dataclass
-from contextlib import contextmanager
-
-from dbt.adapters.base import Credentials
-from dbt.adapters.base import BaseConnectionManager
-from dbt.clients import agate_helper
-import dbt.exceptions
-from dbt.contracts.connection import Connection, ConnectionState, AdapterResponse
-from dbt.logger import GLOBAL_LOGGER as logger
-import duckdb
-import typing as tp
-import agate
-import pathlib
 import os
+import pathlib
+import threading
+import typing as tp
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+import agate
+import duckdb
+import fs.base
+import fs.osfs
+
+import dbt.exceptions
+from . import util
+from dbt.adapters.base import BaseConnectionManager
+from dbt.adapters.base import Credentials
+from dbt.clients import agate_helper
+from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import Connection
+from dbt.contracts.connection import ConnectionState
+from dbt.logger import GLOBAL_LOGGER as logger
 
 
 @dataclass
 class ParquetCredentials(Credentials):
-    database: str = os.getcwd()
+    database: str
     schema: str = ""
 
     @property
     def type(self):
         return "parquet"
+
+    def create_fs_interface(self) -> fs.base.FS:
+        if os.path.exists(self.database):
+            db_folder = fs.osfs.OSFS(self.database)
+            return db_folder
+        raise FileNotFoundError(f"folder {self.database} not found")
 
     def _connection_keys(self):
         # return an iterator of keys to pretty-print in 'dbt debug'.
@@ -29,20 +42,71 @@ class ParquetCredentials(Credentials):
 
     def __post_init__(self):
         if not pathlib.Path(self.database).is_absolute():
-            self.database = str(pathlib.Path.cwd() / self.database)
+            db_path = pathlib.Path.cwd() / self.database
+        else:
+            db_path = pathlib.Path(self.database)
+        self.database = str(db_path.resolve())
+
+
+@dataclass
+class ParquetHandle:
+    db: duckdb.DuckDBPyConnection
+    fs: fs.base.FS
+
+    def close(self):
+        self.db.close()
 
 
 class ParquetConnectionManager(BaseConnectionManager):
     TYPE = "parquet"
+    FS: tp.Optional[fs.base.FS] = None
+    CONN: tp.Optional[duckdb.DuckDBPyConnection] = None
+    LOCK = threading.RLock()
+    CONNECTION_COUNT = 0
 
     @classmethod
     def open(cls, connection: Connection):
 
         if connection.state == ConnectionState.OPEN:
             return connection
+        if cls.FS is None:
+            cls.FS = connection.credentials.create_fs_interface()
 
-        connection.handle = duckdb.connect()
+        with cls.LOCK:
+            if cls.CONN is None:
+                cls.CONN = duckdb.connect()
+
+                # first connection -- initialize all the existing tables
+                for schema in util.list_schemas_from_fs(cls.FS):
+                    if schema:
+                        cls.CONN.execute(f"create schema if not exists {schema}")
+
+                    relations = util.list_relations_from_fs(
+                        cls.FS, connection.credentials.database, schema
+                    )
+                    for relation in relations:
+                        cls.CONN.execute(relation.register_as_view_cmd())
+
+        connection.handle = ParquetHandle(db=cls.CONN.cursor(), fs=cls.FS)
+        cls.CONNECTION_COUNT += 1
         connection.state = ConnectionState.OPEN
+        return connection
+
+    @classmethod
+    def close(cls, connection: Connection) -> Connection:
+        if connection.state in {ConnectionState.CLOSED, ConnectionState.INIT}:
+            return connection
+
+        connection = super().close(connection)
+        if connection.state == ConnectionState.CLOSED:
+            with cls.LOCK:
+                cls.CONNECTION_COUNT -= 1
+                if cls.CONNECTION_COUNT == 0 and cls.CONN:
+                    # close the filesystem to ensure writes
+                    # we keep the in-memory duckdb connection alive so that we don't need to reload metadata
+                    if cls.FS is not None:
+                        cls.FS.close()
+                        cls.FS = None
 
         return connection
 
@@ -62,7 +126,7 @@ class ParquetConnectionManager(BaseConnectionManager):
         pass
 
     @contextmanager
-    def exception_handler(self, sql: str, connection_name="master"):
+    def exception_handler(self, sql: str, connection_name="main"):
         try:
             yield
         except dbt.exceptions.RuntimeException:
@@ -82,13 +146,16 @@ class ParquetConnectionManager(BaseConnectionManager):
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
     ) -> tp.Tuple[AdapterResponse, agate.Table]:
-        conn: duckdb.DuckDBPyConnection = self.get_thread_connection().handle
+        cur: duckdb.DuckDBPyConnection = self.get_thread_connection().handle.db
+        try:
+            r = cur.execute(sql)
+            if fetch:
+                table = self.get_table_from_response(r)
+            else:
+                table = agate_helper.empty_table()
 
-        r = conn.execute(sql)
-        if fetch:
-            table = self.get_table_from_response(r)
-        else:
-            table = agate_helper.empty_table()
+        except Exception as e:
+            raise dbt.exceptions.RuntimeException(str(e))
 
         message = "OK"
         response = AdapterResponse(_message=message)

--- a/dbt/adapters/parquet/impl.py
+++ b/dbt/adapters/parquet/impl.py
@@ -1,14 +1,22 @@
-from dbt.adapters.base import BaseAdapter, RelationType, available
+import os
+import subprocess
+import typing as tp
+
+import agate
+import duckdb
+import fs.base
+import fs.errors
+
+import dbt.exceptions
+from . import util
+from .column import ParquetColumn
+from .relation import ParquetRelation
+from dbt.adapters.base import available
+from dbt.adapters.base import BaseAdapter
+from dbt.adapters.base import BaseRelation
+from dbt.adapters.base import RelationType
 from dbt.adapters.parquet import ParquetConnectionManager
 from dbt.events import AdapterLogger
-import dbt.exceptions
-from pathlib import Path
-from .relation import ParquetRelation
-from .column import ParquetColumn
-import os
-import typing as tp
-import agate
-import subprocess
 
 logger = AdapterLogger("Parquet")
 
@@ -34,6 +42,20 @@ class ParquetAdapter(BaseAdapter):
     def is_cancelable(cls):
         return False
 
+    def get_conn_handle(self) -> duckdb.DuckDBPyConnection:
+        """
+        Get a handle to the in-memory duckdb connection
+        """
+        handle = self.connections.get_thread_connection().handle
+        return handle.db
+
+    def get_fs_handle(self) -> fs.base.FS:
+        """
+        Get a handle to the root PyFilesystem directory that acts as our "database"
+        """
+        handle = self.connections.get_thread_connection().handle
+        return handle.fs
+
     def drop_relation(self, relation: ParquetRelation) -> None:
         is_cached = self._schema_is_cached(relation.database, relation.schema)  # type: ignore[arg-type]
         if is_cached:
@@ -41,8 +63,8 @@ class ParquetAdapter(BaseAdapter):
 
         path = relation.render_path()
         try:
-            os.remove(path)
-        except FileNotFoundError:
+            self.get_fs_handle().remove(path)
+        except fs.errors.ResourceNotFound:
             pass
 
     def truncate_relation(self, relation: ParquetRelation) -> None:
@@ -53,24 +75,31 @@ class ParquetAdapter(BaseAdapter):
     def rename_relation(
         self, from_relation: ParquetRelation, to_relation: ParquetRelation
     ) -> None:
-
+        if from_relation.render() == to_relation.render():
+            return
         self.cache_renamed(from_relation, to_relation)
-        os.rename(from_relation.render_path(), to_relation.render_path())
+        self.get_fs_handle().move(
+            from_relation.render_resource_path(), to_relation.render_resource_path()
+        )
+        self.execute(f"drop view if exists {from_relation.render()}")
+        self.execute(to_relation.register_as_view_cmd())
 
     @available
     def list_schemas(self, database: str) -> tp.List[str]:
-        return sorted(os.listdir(database))
+        # assume there is only ever one database
+        root_dir = self.get_fs_handle()
+        return util.list_schemas_from_fs(root_dir)
 
     @available.parse_none
     def check_schema_exists(self, database: str, schema: str) -> bool:
         return schema in self.list_schemas(database)
 
     def get_columns_in_relation(self, relation: ParquetRelation) -> tp.List[ParquetColumn]:
-        conn = self.connections.get_thread_connection()
-        client = conn.handle
-
+        conn = self.get_conn_handle()
+        if not os.path.exists(relation.render_path()):
+            return []
         q = f"select * from {relation.render_parquet_scan()} LIMIT 0"
-        as_arrow = client.execute(q).arrow()
+        as_arrow = conn.execute(q).arrow()
         return [ParquetColumn(column=f.name, dtype=f.type) for f in as_arrow.schema]
 
     def expand_column_types(self, goal: ParquetRelation, current: ParquetRelation) -> None:  # type: ignore[override]
@@ -87,56 +116,51 @@ class ParquetAdapter(BaseAdapter):
     def list_relations_without_caching(
         self, schema_relation: ParquetRelation
     ) -> tp.List[ParquetRelation]:
+        root_dir = self.get_fs_handle()
+        pq = schema_relation.include(database=True, schema=True, identifier=False).parquet_table
+        schema = pq.schema
+        relations = util.list_relations_from_fs(root_dir, schema_relation.database, schema)
+        # if schema:
+        #     self.execute(f"create schema if not exists {schema}")
 
-        relations = []
-        for schema in os.listdir(
-            schema_relation.include(database=True, schema=False, identifier=False).render_path()
-        ):
-            identifier = schema.split(".parquet")[0]
-
-            relation = ParquetRelation.create(
-                database=schema_relation.database,
-                schema=schema_relation.schema,
-                identifier=identifier,
-                type=RelationType.Table,
-            )
-            relations.append(relation)
+        for relation in relations:
+            self.execute(relation.register_as_view_cmd())
         return relations
 
     def create_schema(self, relation: ParquetRelation) -> None:
-        schema_path = relation.include(identifier=False).render_path()
-        logger.debug("Creating schema {} in cwd: {}.", schema_path, os.getcwd())
+        schema_path = relation.include(identifier=False).render_resource_path()
         try:
-            os.mkdir(schema_path)
-        except FileExistsError:
+            root_dir = self.get_fs_handle()
+            root_dir.makedir(schema_path)
+        except fs.errors.DirectoryExists:
             pass
+        self.execute(f"create schema if not exists {relation.schema}")
+        self.cache.add_schema(relation.database, relation.schema)
 
     def drop_schema(self, relation: ParquetRelation) -> None:
         database = relation.database
-        schema = relation.schema
-        schema_path = relation.include(identifier=False).render_path()
-        logger.debug("Dropping schema {} in cwd: {}.", schema_path, os.getcwd())
+        schema = relation.schema or "/"
+        root_dir = self.get_fs_handle()
         try:
-            for p in Path(schema_path).glob("*.parquet"):
-                os.remove(p)
-            os.rmdir(schema_path)
-        except FileNotFoundError:
+            root_dir.removetree(schema)
+        except fs.errors.ResourceNotFound:
             pass
+        self.execute(f"drop schema if exists {relation.schema} cascade")
         self.cache.drop_schema(database, schema)
 
     @available
     def load_dataframe(self, database, schema, table_name, agate_table):
-        conn = self.connections.get_thread_connection()
-        client = conn.handle
+        conn = self.get_conn_handle()
         csv_file = agate_table.original_abspath
         rel = ParquetRelation.create(database, schema, table_name)
-        client.execute(
+        conn.execute(
             f"""
             copy
                 (select * from read_csv_auto('{csv_file}'))
             to '{rel.render_path()}' (format 'parquet');
             """
         )
+        conn.execute(rel.register_as_view_cmd())
 
     def run_sql_for_tests(self, sql, fetch, conn=None):
         """
@@ -145,6 +169,7 @@ class ParquetAdapter(BaseAdapter):
         """
 
         do_fetch = fetch != "None"
+
         _, res = self.execute(sql, fetch=do_fetch)
 
         # convert dataframe to matrix-ish repr
@@ -182,20 +207,30 @@ class ParquetAdapter(BaseAdapter):
     def convert_time_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         return "time"
 
-    @available
-    def duckdb(self):
-        cmds = ["install parquet", "load parquet"]
+    def _register_view_cmds(self) -> tp.List[str]:
+        """
+        Return the set of sql commands needed to register all the parquet files as
+        views in duckdb.
+        """
+        cmds = []
         db = self.config.credentials.database
         for schema in self.list_schemas(db):
-            cmds.append(f"create schema {schema}")
-            for rel in self.list_relations(db, schema):
-                view_name = rel.identifier
-                cmds.append(
-                    f"""
-                    create view {schema}.{view_name} as
-                        select * from {rel.render()}
-                    """
-                )
+            if schema:
+                cmds.append(f"create schema if not exists {schema}")
+            relations = tp.cast(tp.List[ParquetRelation], self.list_relations(db, schema))
+            for rel in relations:
+                cmds.append(rel.register_as_view_cmd())
+        return cmds
+
+    @available
+    def duckdb(self):
+        """
+        Run the duckdb CLI with each parquet files having a corresponding view
+
+        Usage: `dbt run-operation duckdb`
+        """
+        cmds = ["install parquet", "load parquet"]
+        cmds.extend(self._register_view_cmds())
         cmds.append(
             """
             select
@@ -205,4 +240,70 @@ class ParquetAdapter(BaseAdapter):
             order by all
             """
         )
+        try:
+            subprocess.run(["duckdb", "--version"]).check_returncode()
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                "duckdb cli not installed. See instructions at https://duckdb.org/ or use a package manager like homebrew"
+            ) from e
         subprocess.run(["duckdb", "-cmd", "; ".join(cmds)])
+
+    def get_rows_different_sql(
+        self,
+        relation_a: BaseRelation,
+        relation_b: BaseRelation,
+        column_names: tp.Optional[tp.List[str]] = None,
+        except_operator: str = "EXCEPT",
+    ) -> str:
+        """Generate SQL for a query that returns a single row with a two
+        columns: the number of rows that are different between the two
+        relations and the number of mismatched rows.
+        """
+        # This method only really exists for test reasons.
+        names: tp.List[str]
+        if column_names is None:
+            columns = self.get_columns_in_relation(tp.cast(ParquetRelation, relation_a))
+            names = sorted((self.quote(c.name) for c in columns))
+        else:
+            names = sorted((self.quote(n) for n in column_names))
+        columns_csv = ", ".join(names)
+
+        sql = COLUMNS_EQUAL_SQL.format(
+            columns=columns_csv,
+            relation_a=str(tp.cast(ParquetRelation, relation_a)),
+            relation_b=str(tp.cast(ParquetRelation, relation_b)),
+            except_op=except_operator,
+        )
+
+        return sql
+
+
+# Change `table_a/b` to `table_aaaaa/bbbbb` to avoid duckdb binding issues when relation_a/b
+# is called "table_a" or "table_b" in some of the dbt tests
+COLUMNS_EQUAL_SQL = """
+with diff_count as (
+    SELECT
+        1 as id,
+        COUNT(*) as num_missing FROM (
+            (SELECT {columns} FROM {relation_a} {except_op}
+             SELECT {columns} FROM {relation_b})
+             UNION ALL
+            (SELECT {columns} FROM {relation_b} {except_op}
+             SELECT {columns} FROM {relation_a})
+        ) as a
+), table_aaaaa as (
+    SELECT COUNT(*) as num_rows FROM {relation_a}
+), table_bbbbb as (
+    SELECT COUNT(*) as num_rows FROM {relation_b}
+), row_count_diff as (
+    select
+        1 as id,
+        table_aaaaa.num_rows - table_bbbbb.num_rows as difference
+    from table_aaaaa, table_bbbbb
+)
+select
+    row_count_diff.difference as row_count_difference,
+    diff_count.num_missing as num_mismatched
+from row_count_diff
+join diff_count using (id)
+""".strip()

--- a/dbt/adapters/parquet/util.py
+++ b/dbt/adapters/parquet/util.py
@@ -1,0 +1,44 @@
+import typing as tp
+
+import fs.base
+
+from .relation import ParquetRelation
+from dbt.adapters.base import RelationType
+
+
+def list_schemas_from_fs(root_dir: fs.base.FS):
+    """
+    List all the schemas in the filesystem.
+
+    This is just all subfolders plus the default (empty) schema
+    """
+    folders = root_dir.filterdir("/", exclude_files=["*"])
+
+    # include the empty, i.e. default schema in the response
+    return [""] + sorted([d.name for d in folders])
+
+
+def list_relations_from_fs(
+    root_dir: fs.base.FS, database: tp.Optional[str], schema: str
+) -> tp.List[ParquetRelation]:
+    """
+    List all relations within a "schema" subfolder.
+
+    This is all parquet files under the subfolder.
+    File 'blah.parquet' is mapped to identifier "blah".
+    """
+
+    subdir = "/" + schema if schema else "/"
+    if not root_dir.exists(subdir):
+        return []
+
+    relations = []
+    for item in root_dir.filterdir(subdir, files=["*.parquet"], exclude_dirs=["*"]):
+        relation = ParquetRelation.create(
+            database=database,
+            schema=schema,
+            identifier=item.name[: -len(".parquet")],
+            type=RelationType.Table,
+        )
+        relations.append(relation)
+    return relations

--- a/dbt/include/parquet/macros/adapters.sql
+++ b/dbt/include/parquet/macros/adapters.sql
@@ -7,48 +7,17 @@ dbt docs: https://docs.getdbt.com/docs/contributing/building-a-new-adapter
   {%- set sql_header = config.get('sql_header', none) -%}
   {{ sql_header if sql_header is not none }}
 
-  {% for node in model['depends_on']['nodes'] %}
-    {% set source = graph['sources'].get(node) or graph['nodes'][node] %}
-
-    {% if source %}
-
-      {% set src_rel = relation.create(
-          database=source['database'],
-          schema=source['schema'],
-          identifier=source['identifier']
-      ) %}
-      {% do log(src_rel, info=true) %}
-      create or replace view {{ src_rel.render() }} as
-        select * from {{ src_rel.render_parquet_scan() }};
-    {% endif %}
-  {% endfor %}
-  copy ({{ sql }}) to '{{ relation.render_path() }}' (format 'parquet')
-  ;
+  copy ({{ sql }}) to '{{ relation.render_path() }}' (format 'parquet');
+  {{ relation.register_as_view_cmd() }};
 {%- endmacro %}
-
 
 {% macro parquet__create_view_as(relation, sql) -%}
   -- For a parquet file, View == Table.
   {%- set sql_header = config.get('sql_header', none) -%}
   {{ sql_header if sql_header is not none }}
 
-  {% for node in model['depends_on']['nodes'] %}
-    {% set source = graph['sources'].get(node) or graph['nodes'][node] %}
-
-    {% if source %}
-
-      {% set src_rel = relation.create(
-          database=source['database'],
-          schema=source['schema'],
-          identifier=source['identifier']
-      ) %}
-      {% do log(src_rel, info=true) %}
-      create or replace view {{ src_rel.render() }} as
-        select * from {{ src_rel.render_parquet_scan() }};
-    {% endif %}
-  {% endfor %}
-  copy ({{ sql }}) to '{{ relation.render_path() }}' (format 'parquet')
-  ;
+  copy ({{ sql }}) to '{{ relation.render_path() }}' (format 'parquet');
+  {{ relation.register_as_view_cmd() }};
 {%- endmacro %}
 
 {% macro parquet__snapshot_string_as_time(timestamp) -%}
@@ -59,7 +28,6 @@ dbt docs: https://docs.getdbt.com/docs/contributing/building-a-new-adapter
 {% macro parquet__snapshot_get_time() -%}
   {{ current_timestamp() }}::timestamp
 {%- endmacro %}
-
 
 {% macro parquet__current_timestamp() -%}
 '''Returns current UTC time'''

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter~=1.2.0
+dbt-tests-adapter~=1.3.0
 
 black==22.3.0
 bumpversion
@@ -6,7 +6,7 @@ flake8
 flaky
 freezegun==0.3.12
 ipdb
-mypy==0.782
+mypy==0.982
 pip-tools
 pre-commit
 pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,5 @@
 [pytest]
 filterwarnings =
-    ignore:.*"soft_unicode" has been renamed to "soft_str"*:DeprecationWarning
-    ignore:unclosed file .*:ResourceWarning
 env_files =
     test.env
 testpaths =

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_namespace_packages
+from setuptools import find_namespace_packages
+from setuptools import setup
 
 setup(
     name="dbt-parquet",
@@ -10,13 +11,14 @@ setup(
     ],
     keywords=["parquet", "dbt", "duckdb"],
     readme="README.md",
-    version="1.2.1",
+    version="1.3.0",
     author="Alexander Vandenberg-Rodes",
     author_email="alexvr+dbt@gmail.com",
     python_requires=">=3.7",
     install_requires=[
-        "dbt-core~=1.2.0",
+        "dbt-core~=1.3.0",
         "duckdb==0.5.1",
+        "fs-s3fs>=1.1.0",
         "pyarrow>=7.0.0",
     ],
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,15 +6,17 @@ import pathlib
 
 pytest_plugins = ["dbt.tests.fixtures.project"]
 
+# all testing data goes here
 _TESTING_DATA_LOC = pathlib.Path(__file__).parent / "data"
+
 
 # The profile dictionary, used to write out profiles.yml
 @pytest.fixture(scope="class")
 def dbt_profile_target():
     _TESTING_DATA_LOC.mkdir(exist_ok=True)
-    
+
     return {
         "type": "parquet",
-        "threads": 1,
+        "threads": 4,
         "database": str(_TESTING_DATA_LOC),
     }

--- a/tests/functional/basic/test_basic.py
+++ b/tests/functional/basic/test_basic.py
@@ -13,8 +13,57 @@ from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCo
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 
+from dbt.tests.util import (
+    run_dbt,
+    check_result_nodes_by_name,
+    relation_from_name,
+    check_relations_equal,
+)
+
 
 class TestSimpleMaterializationsParquet(BaseSimpleMaterializations):
+    def test_base(self, project):
+        """
+        Override existing test_base to:
+          - remove calls to check_relation_types, as everything is a table
+          - remove incremental materialization test, since these are not supported
+        """
+
+        # seed command
+        results = run_dbt(["seed"])
+        # seed result length
+        assert len(results) == 1
+
+        # run command
+        results = run_dbt()
+        # run result length
+        assert len(results) == 3
+
+        # names exist in result nodes
+        check_result_nodes_by_name(results, ["view_model", "table_model", "swappable"])
+
+        # base table rowcount
+        relation = relation_from_name(project.adapter, "base")
+        result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
+        assert result[0] == 10
+
+        # relations_equal
+        check_relations_equal(project.adapter, ["base", "view_model", "table_model", "swappable"])
+
+        # check relations in catalog
+        catalog = run_dbt(["docs", "generate"])
+        assert len(catalog.nodes) == 4
+        assert len(catalog.sources) == 1
+
+        # run_dbt changing materialized_var to view
+        if project.test_config.get("require_full_refresh", False):  # required for BigQuery
+            results = run_dbt(
+                ["run", "--full-refresh", "-m", "swappable", "--vars", "materialized_var: view"]
+            )
+        else:
+            results = run_dbt(["run", "-m", "swappable", "--vars", "materialized_var: view"])
+        assert len(results) == 1
+
     pass
 
 

--- a/tests/functional/basic/test_concurrency.py
+++ b/tests/functional/basic/test_concurrency.py
@@ -1,0 +1,3 @@
+from dbt.tests.adapter.concurrency.test_concurrency import TestConcurenncy
+class TestConcurrencyParquet(TestConcurenncy):
+    pass

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -1,0 +1,45 @@
+from dbt.tests.util import get_connection
+from .util import config_from_parts_or_dicts
+from dbt.adapters.parquet.impl import ParquetAdapter
+from dbt.adapters.parquet.relation import ParquetRelation
+import pytest
+import tempfile
+
+@pytest.fixture()
+def adapter():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        profile_cfg = {
+            'outputs': {
+                'test': {
+                    "type": "parquet",
+                    "threads": 1,
+                    "database": tmpdir,
+                },
+            },
+            'target': 'test',
+        }
+
+        project_cfg = {
+            'name': 'X',
+            'version': '0.1',
+            'profile': 'test',
+            'project-root': '/tmp/dbt/does-not-exist',
+            'quoting': {
+                'identifier': False,
+                'schema': True,
+            },
+            'query-comment': 'dbt',
+            'config-version': 2,
+        }
+        config = config_from_parts_or_dicts(project_cfg, profile_cfg)
+        a = ParquetAdapter(config)
+        with get_connection(a):
+            yield a 
+
+def test_schema_add_drop(adapter):
+    schema = "my_schema"
+    as_relation = ParquetRelation.create(schema=schema)
+    db = adapter.config.credentials.database
+    adapter.create_schema(as_relation)
+    
+    assert adapter.list_schemas(db) == ['', schema]

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -1,0 +1,78 @@
+import os
+
+from dbt.config.project import PartialProject
+
+
+class Obj:
+    which = 'blah'
+    single_threaded = False
+
+
+def profile_from_dict(profile, profile_name, cli_vars='{}'):
+    from dbt.config import Profile
+    from dbt.config.renderer import ProfileRenderer
+    from dbt.context.base import generate_base_context
+    from dbt.config.utils import parse_cli_vars
+    if not isinstance(cli_vars, dict):
+        cli_vars = parse_cli_vars(cli_vars)
+
+    renderer = ProfileRenderer(cli_vars)
+    return Profile.from_raw_profile_info(
+        profile,
+        profile_name,
+        renderer,
+    )
+
+
+def project_from_dict(project, profile, packages=None, selectors=None, cli_vars='{}'):
+    from dbt.config.renderer import DbtProjectYamlRenderer
+    from dbt.config.utils import parse_cli_vars
+    if not isinstance(cli_vars, dict):
+        cli_vars = parse_cli_vars(cli_vars)
+
+    renderer = DbtProjectYamlRenderer(profile, cli_vars)
+    project_root = project.pop('project-root', os.getcwd())
+
+    partial = PartialProject.from_dicts(
+        project_root=project_root,
+        project_dict=project,
+        packages_dict=packages,
+        selectors_dict=selectors,
+    )
+    return partial.render(renderer)
+
+
+
+def config_from_parts_or_dicts(project, profile, packages=None, selectors=None, cli_vars='{}'):
+    from dbt.config import Project, Profile, RuntimeConfig
+    from copy import deepcopy
+
+    if isinstance(project, Project):
+        profile_name = project.profile_name
+    else:
+        profile_name = project.get('profile')
+
+    if not isinstance(profile, Profile):
+        profile = profile_from_dict(
+            deepcopy(profile),
+            profile_name,
+            cli_vars,
+        )
+
+    if not isinstance(project, Project):
+        project = project_from_dict(
+            deepcopy(project),
+            profile,
+            packages,
+            selectors,
+            cli_vars,
+        )
+
+    args = Obj()
+    args.vars = cli_vars
+    args.profile_dir = '/dev/null'
+    return RuntimeConfig.from_parts(
+        project=project,
+        profile=profile,
+        args=args
+    )


### PR DESCRIPTION
Initialize all relations as views in duckdb on startup instead of on-demand through the dbt graph.

Use PyFilesystem2 to abstract out os filesystem calls and enable future interoperatability with cloud storage.  

Add proper concurrency with a shared metadata catalog stored in the memory-based duckdb connection.